### PR TITLE
Revert check-purpose commit

### DIFF
--- a/hubs/ashm_hubs/grch37_hub.txt
+++ b/hubs/ashm_hubs/grch37_hub.txt
@@ -12,7 +12,7 @@ longLabel Regions of interest from where mutations were retrieved
 visibility squish
 priority 1
 type bigBed
-bigDataUrl https://github.com/morinlab/LLMPP/blob/vsouza_fix_hub/hubs/ashm_hubs/grch37/regions.bb?raw=true
+bigDataUrl https://github.com/morinlab/LLMPP/blob/main/hubs/ashm_hubs/grch37/regions.bb?raw=true
 
 track genome_BL
 shortLabel genome_BL
@@ -21,7 +21,7 @@ visibility squish
 priority 2
 type bigBed 9
 itemRgb on
-bigDataUrl https://github.com/morinlab/LLMPP/blob/vsouza_fix_hub/hubs/ashm_hubs/grch37/genome_BL.bb?raw=true
+bigDataUrl https://github.com/morinlab/LLMPP/blob/main/hubs/ashm_hubs/grch37/genome_BL.bb?raw=true
 
 track genome_DLBCL
 shortLabel genome_DLBCL
@@ -30,7 +30,7 @@ visibility squish
 priority 3
 type bigBed 9
 itemRgb on
-bigDataUrl https://github.com/morinlab/LLMPP/blob/vsouza_fix_hub/hubs/ashm_hubs/grch37/genome_DLBCL.bb?raw=true
+bigDataUrl https://github.com/morinlab/LLMPP/blob/main/hubs/ashm_hubs/grch37/genome_DLBCL.bb?raw=true
 
 track genome_FL
 shortLabel genome_FL
@@ -39,7 +39,7 @@ visibility squish
 priority 4
 type bigBed 9
 itemRgb on
-bigDataUrl https://github.com/morinlab/LLMPP/blob/vsouza_fix_hub/hubs/ashm_hubs/grch37/genome_FL.bb?raw=true
+bigDataUrl https://github.com/morinlab/LLMPP/blob/main/hubs/ashm_hubs/grch37/genome_FL.bb?raw=true
 
 track capture_DLBCL
 shortLabel capture_DLBCL
@@ -48,4 +48,4 @@ visibility squish
 priority 5
 type bigBed 9
 itemRgb on
-bigDataUrl https://github.com/morinlab/LLMPP/blob/vsouza_fix_hub/hubs/ashm_hubs/grch37/capture_DLBCL.bb?raw=true
+bigDataUrl https://github.com/morinlab/LLMPP/blob/main/hubs/ashm_hubs/grch37/capture_DLBCL.bb?raw=true

--- a/hubs/ashm_hubs/hg38_hub.txt
+++ b/hubs/ashm_hubs/hg38_hub.txt
@@ -12,7 +12,7 @@ longLabel Regions of interest from where mutations were retrieved
 visibility squish
 priority 1
 type bigBed
-bigDataUrl https://github.com/morinlab/LLMPP/blob/vsouza_fix_hub/hubs/ashm_hubs/hg38/regions.bb?raw=true
+bigDataUrl https://github.com/morinlab/LLMPP/blob/main/hubs/ashm_hubs/hg38/regions.bb?raw=true
 
 track genome_BL
 shortLabel genome_BL
@@ -21,7 +21,7 @@ visibility squish
 priority 2
 type bigBed 9
 itemRgb on
-bigDataUrl https://github.com/morinlab/LLMPP/blob/vsouza_fix_hub/hubs/ashm_hubs/hg38/genome_BL.bb?raw=true
+bigDataUrl https://github.com/morinlab/LLMPP/blob/main/hubs/ashm_hubs/hg38/genome_BL.bb?raw=true
 
 track genome_DLBCL
 shortLabel genome_DLBCL
@@ -30,7 +30,7 @@ visibility squish
 priority 3
 type bigBed 9
 itemRgb on
-bigDataUrl https://github.com/morinlab/LLMPP/blob/vsouza_fix_hub/hubs/ashm_hubs/hg38/genome_DLBCL.bb?raw=true
+bigDataUrl https://github.com/morinlab/LLMPP/blob/main/hubs/ashm_hubs/hg38/genome_DLBCL.bb?raw=true
 
 track genome_FL
 shortLabel genome_FL
@@ -39,7 +39,7 @@ visibility squish
 priority 4
 type bigBed 9
 itemRgb on
-bigDataUrl https://github.com/morinlab/LLMPP/blob/vsouza_fix_hub/hubs/ashm_hubs/hg38/genome_FL.bb?raw=true
+bigDataUrl https://github.com/morinlab/LLMPP/blob/main/hubs/ashm_hubs/hg38/genome_FL.bb?raw=true
 
 track capture_DLBCL
 shortLabel capture_DLBCL
@@ -48,4 +48,4 @@ visibility squish
 priority 5
 type bigBed 9
 itemRgb on
-bigDataUrl https://github.com/morinlab/LLMPP/blob/vsouza_fix_hub/hubs/ashm_hubs/hg38/capture_DLBCL.bb?raw=true
+bigDataUrl https://github.com/morinlab/LLMPP/blob/main/hubs/ashm_hubs/hg38/capture_DLBCL.bb?raw=true


### PR DESCRIPTION
I'm very sorry for my distraction. [Last PR](https://github.com/morinlab/LLMPP/pull/4), I should have reverted [this commit](https://github.com/morinlab/LLMPP/pull/4/commits/4bc0204f27af423548de266303fe16e77b56774d), which was only for checking purposes.